### PR TITLE
Replaced @Injectable decorator with @Service

### DIFF
--- a/apps/ui/src/app/core/fw-extensions/app-router.ts
+++ b/apps/ui/src/app/core/fw-extensions/app-router.ts
@@ -1,9 +1,7 @@
-import { Injectable } from "@angular/core";
-import { Router } from "@angular/router";
+import { Service } from '@angular/core';
+import { Router } from '@angular/router';
 
-@Injectable({
-	providedIn: 'root'
-})
+@Service()
 export class AppRouter extends Router {
 	async navigateToLogin() {
 		await this.navigateByUrl('/login');

--- a/apps/ui/src/app/core/services/store/store.service.ts
+++ b/apps/ui/src/app/core/services/store/store.service.ts
@@ -1,9 +1,7 @@
-import { Injectable, inject } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { AppStore } from '../../store/app.store';
 
-@Injectable({
-	providedIn: 'root',
-})
+@Service()
 export class StoreService {
 	readonly #store = inject(AppStore);
 

--- a/apps/ui/src/app/features/auth/services/auth.service.ts
+++ b/apps/ui/src/app/features/auth/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { computed, inject, Injectable, signal } from '@angular/core';
+import { computed, inject, Service, signal } from '@angular/core';
 import { AuthKeys } from '@gh/shared/models';
 import { loggedMethod } from '@gh/shared/utils';
 import { StoreService } from 'core/services/store/store.service';
@@ -12,9 +12,7 @@ type Credentials = {
 	refreshToken: string;
 };
 
-@Injectable({
-	providedIn: 'root',
-})
+@Service()
 export class AuthService {
 	readonly #storeService = inject(StoreService);
 	readonly #http = inject(HttpClient);

--- a/apps/ui/src/app/features/gh/services/gh-user.service.ts
+++ b/apps/ui/src/app/features/gh/services/gh-user.service.ts
@@ -1,9 +1,7 @@
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
-@Injectable({
-	providedIn: 'root',
-})
+@Service()
 export class GhUserService {
 	#userCardsShowFace$ = new BehaviorSubject<boolean>(false);
 	userCardsShowFace$ = this.#userCardsShowFace$.asObservable();

--- a/apps/ui/src/app/features/gh/services/gh.service.ts
+++ b/apps/ui/src/app/features/gh/services/gh.service.ts
@@ -1,12 +1,10 @@
 import { HttpClient, httpResource } from '@angular/common/http';
-import { Injectable, Signal, inject } from '@angular/core';
+import { inject, Service, Signal } from '@angular/core';
 import { GhFullUser, GhRepoContributor, GhRepoLanguages, GhUser, GhUserRepo, GhUsersSearchResults } from '@gh/shared/models';
 import { loggedMethod } from '@gh/shared/utils';
-import { EMPTY, catchError, expand, reduce, tap, throwError } from 'rxjs';
+import { catchError, EMPTY, expand, reduce, tap, throwError } from 'rxjs';
 
-@Injectable({
-	providedIn: 'root',
-})
+@Service()
 export class GhService {
 	readonly #http = inject(HttpClient);
 	readonly #baseApiUrl = '/api/github';


### PR DESCRIPTION
From Angular 22 `@Service()` is equivalent to `@Injectable({ providedIn: 'root' })`